### PR TITLE
fix: contextSelected not triggered

### DIFF
--- a/src/VContext/VContext.vue
+++ b/src/VContext/VContext.vue
@@ -46,7 +46,9 @@ export default {
           this.showContext = true;
         });
       } else if (this.mouseEvent.button === 0) {
-        this.showContext = false;
+        this.$nextTick(() => {
+          this.showContext = false;
+        })
       }
     }
   }


### PR DESCRIPTION
Without the fix,  ContextMenu is hidden before click event is triggered